### PR TITLE
Fix: Show context info in footer even when model limit config is missing

### DIFF
--- a/src/session/stats.ts
+++ b/src/session/stats.ts
@@ -110,13 +110,16 @@ export async function buildFooter(
   let percentText = "";
   try {
     const limit = await getModelLimit(options.getClient, options.directory, options.model);
-    if (limit?.context) {
-      const tokens = info ? readTokensFromAssistantMessage(info) : undefined;
-      const totalTokens = tokens
-        ? tokens.input + tokens.output + tokens.reasoning + tokens.cacheRead + tokens.cacheWrite
-        : 0;
-      if (totalTokens > 0) {
+    const tokens = info ? readTokensFromAssistantMessage(info) : undefined;
+    const totalTokens = tokens
+      ? tokens.input + tokens.output + tokens.reasoning + tokens.cacheRead + tokens.cacheWrite
+      : 0;
+
+    if (totalTokens > 0) {
+      if (limit?.context) {
         percentText = formatPercentRatio(totalTokens / limit.context);
+      } else {
+        percentText = `${(totalTokens / 1000).toFixed(1)}k`;
       }
     }
   } catch {


### PR DESCRIPTION
When switching to a model that doesn't have limit.context configured, the footer previously showed '元信息' instead of '上下文 xx%' because the context percentage couldn't be calculated.

This change uses a default context limit (128k) when the model's limit configuration is unavailable, ensuring the footer always shows context information when token usage is available.